### PR TITLE
Fix deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 export CC_JAVA_VERSION=graalvm-ce
 export CC_MAVEN_PROFILES=native
 export CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner
-export MAVEN_DEPLOY_GOAL="spring-boot:run"
+export GRADLE_DEPLOY_GOAL="spring-boot:run"

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 export CC_JAVA_VERSION=graalvm-ce
 export CC_MAVEN_PROFILES=native
 export CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner
+export MAVEN_DEPLOY_GOAL="spring-boot:run"

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+export CC_JAVA_VERSION=graalvm-ce
+export CC_MAVEN_PROFILES=native
+export CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.clever.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .clever.json
+.gradle/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Export them using the `.env` file:
 
 Import them on the clever CLI
 
-    clever env import-vars CC_JAVA_VERSION,CC_MAVEN_PROFILES,CC_RUN_COMMAND
+    clever env import-vars CC_JAVA_VERSION,CC_MAVEN_PROFILES,CC_RUN_COMMAND,GRADLE_DEPLOY_GOAL
 
 ## Enjoy
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,37 @@
 You'll first need an account.
 Go to the [console](https://console.clever-cloud.com/) and follow the instructions.
 
-## Create the application
+## Deploy in the console
 
 Create a new application, select "Java + Maven"
 Add these environment variables when prompted to do so:
-- `CC_JAVA_VERSION=graalvm-ce`
-- `CC_MAVEN_PROFILES=native`
-- `CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner`
+
+-   `CC_JAVA_VERSION=graalvm-ce`
+-   `CC_MAVEN_PROFILES=native`
+-   `CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner`
+
+## Deploy using the CLI
+
+Install the [clever cli](https://www.clever-cloud.com/doc/reference/clever-tools/getting_started/),
+it is packaged for npm and for every possible OS.
+
+Within this cloned repository, do:
+
+    clever create --type maven quarkus-example
+
+```
+CC_JAVA_VERSION=graalvm-ce
+CC_MAVEN_PROFILES=native
+CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner
+```
+
+Export them using the `.env` file:
+
+    source .env
+
+Import them on the clever CLI
+
+    clever env import-vars CC_JAVA_VERSION,CC_MAVEN_PROFILES,CC_RUN_COMMAND
 
 ## Enjoy
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Within this cloned repository, do:
 
     clever create --type maven quarkus-example
 
-```
-CC_JAVA_VERSION=graalvm-ce
-CC_MAVEN_PROFILES=native
-CC_RUN_COMMAND=target/quarkus-quickstart-1.0-runner
-```
-
 Export them using the `.env` file:
 
     source .env

--- a/clevercloud/maven.json
+++ b/clevercloud/maven.json
@@ -1,5 +1,0 @@
-{
-    "deploy": {
-        "goal": "-Dtest.active=false -Dexec.mainClass=\"com.example.Main\" assembly:jar-with-dependencies exec:java"
-    }
-}

--- a/clevercloud/maven.json
+++ b/clevercloud/maven.json
@@ -1,0 +1,5 @@
+{
+    "deploy": {
+        "goal": "-Dtest.active=false -Dexec.mainClass=\"com.example.Main\" assembly:jar-with-dependencies exec:java"
+    }
+}


### PR DESCRIPTION
I had those logs:

```
2022-03-09T10:11:21.733Z: Detected gradle app
2022-03-09T10:11:21.733Z: A gradlew script has been found. We will use it instead of /usr/bin/gradle
2022-03-09T10:11:21.733Z: Error: goal is missing for deploying with gradle
2022-03-09T10:11:21.733Z: Deploy failed
```

which isn't so great. So I'm revamping the instructions.

## DO NOT MERGE YET

This does not work yet. Since adding a `clevercloud/maven.json`, things have improved, now the logs are:

```
2022-03-09T18:19:27.679Z: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.1:test (default-test) on project quarkus-quickstart: There are test failures.
```

Maybe that's because I blindedly copy-pasted the example given for `maven.json`. I am not a smart coder. But I'll sort it out.